### PR TITLE
Use a lookahead assertion instead of a capturing character

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@
 
 module.exports = function (Handlebars, delims) {
   if (delims[0].indexOf('=') === -1) {
-    delims[0] = delims[0] + '[^=]';
+    delims[0] = delims[0] + '(?!=)';
   }
 
   var re = new RegExp(delims[0] + '([\\s\\S]+?)' + delims[1], 'g');

--- a/test.js
+++ b/test.js
@@ -8,45 +8,62 @@
 'use strict';
 
 var assert = require('assert');
-var Handlebars = require('handlebars');
 var useDelims = require('./');
 
-
 describe('custom handlebars delimiters', function () {
-  var str = '{%= name %}{{ name }}{{{ name }}}<%= name %><% name %><<= name >><< name >>';
+  var Handlebars, str = '{%= name %}{{ name }}{{{ name }}}<%= name %><% name %><<= name >><< name >>%{name}%{ name }';
+
+  beforeEach(function() {
+    Handlebars = require('handlebars');
+  });
+
+  function testWith(str, expectation) {
+    var actual = Handlebars.compile(str)({name: 'Jon Schlinkert'});
+    assert.equal(actual, expectation);
+  }
 
   it('should use default delimiters', function () {
     var actual = Handlebars.compile(str)({name: 'Jon Schlinkert'});
-    assert.equal(actual, '{%= name %}Jon SchlinkertJon Schlinkert<%= name %><% name %><<= name >><< name >>');
+    testWith(str, '{%= name %}Jon SchlinkertJon Schlinkert<%= name %><% name %><<= name >><< name >>%{name}%{ name }');
   });
 
   it('should use <%=...%>', function () {
     useDelims(Handlebars, ['<%=', '%>']);
-    var actual = Handlebars.compile(str)({name: 'Jon Schlinkert'});
-    assert.equal(actual, '{%= name %}{{ name }}{{{ name }}}Jon Schlinkert<% name %><<= name >><< name >>');
+    testWith(str, '{%= name %}{{ name }}{{{ name }}}Jon Schlinkert<% name %><<= name >><< name >>%{name}%{ name }');
   });
 
   it('should use {%=...%}', function () {
     useDelims(Handlebars, ['{%=', '%}']);
-    var actual = Handlebars.compile(str)({name: 'Jon Schlinkert'});
-    assert.equal(actual, 'Jon Schlinkert{{ name }}{{{ name }}}<%= name %><% name %><<= name >><< name >>');
+    testWith(str, 'Jon Schlinkert{{ name }}{{{ name }}}<%= name %><% name %><<= name >><< name >>%{name}%{ name }');
   });
 
   it('should use <%...%>', function () {
     useDelims(Handlebars, ['<%', '%>']);
-    var actual = Handlebars.compile(str)({name: 'Jon Schlinkert'});
-    assert.equal(actual, '{%= name %}{{ name }}{{{ name }}}<%= name %>Jon Schlinkert<<= name >><< name >>');
+    testWith(str, '{%= name %}{{ name }}{{{ name }}}<%= name %>Jon Schlinkert<<= name >><< name >>%{name}%{ name }');
   });
 
   it('should use <<...>>', function () {
     useDelims(Handlebars, ['<<', '>>']);
-    var actual = Handlebars.compile(str)({name: 'Jon Schlinkert'});
-    assert.equal(actual, '{%= name %}{{ name }}{{{ name }}}<%= name %><% name %><<= name >>Jon Schlinkert');
+    testWith(str, '{%= name %}{{ name }}{{{ name }}}<%= name %><% name %><<= name >>Jon Schlinkert%{name}%{ name }');
   });
 
   it('should use <<=...>>', function () {
     useDelims(Handlebars, ['<<=', '>>']);
-    var actual = Handlebars.compile(str)({name: 'Jon Schlinkert'});
-    assert.equal(actual, '{%= name %}{{ name }}{{{ name }}}<%= name %><% name %>Jon Schlinkert<< name >>');
+    testWith(str, '{%= name %}{{ name }}{{{ name }}}<%= name %><% name %>Jon Schlinkert<< name >>%{name}%{ name }');
+  });
+
+  it('should use %{...} with or without spaces', function () {
+    useDelims(Handlebars, ['%{', '}']);
+    testWith(str, '{%= name %}{{ name }}{{{ name }}}<%= name %><% name %><<= name >><< name >>Jon SchlinkertJon Schlinkert');
+  });
+
+  it('should handle no spaces in first occurence', function () {
+    useDelims(Handlebars, ['%{', '}']);
+    testWith("%{name}", 'Jon Schlinkert');
+  });
+
+  it('should handle spaces in first occurence', function () {
+    useDelims(Handlebars, ['%{', '}']);
+    testWith("%{ name }", 'Jon Schlinkert');
   });
 });


### PR DESCRIPTION
I needed to override the delimiters to match a templating language that does not include spaces around parameter names. I had to change the delimiter to use a lookahead instead of eating a character.
