### PR TITLE
Fix to replace the match instead of the whole regular expression

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function(Handlebars, delims) {
 
     var match;
     while (match = re.exec(args[0])) {
-      args[0] = args[0].replace(re, '{{' + match[1] + '}}');
+      args[0] = args[0].replace(match[0], '{{' + match[1] + '}}');
     }
     return Handlebars._compile.apply(null, args);
   };


### PR DESCRIPTION
This PR will fix the problem that I found when you defined more than one variable placeholder in your original string.

reproduce the error:

`useDelims(Handlebars, ['<%=', '%>']);`
`Handlebars.compile('{{ name }}<%= name %> <%= lastname %>')({name: 'Jon', lastname: 'Doe'});`

will produce

`'{{ name }}Jon <% doe %>'`
