### PR TITLE
Ref #7: Don't remove curly braces

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function(Handlebars, delimiters) {
     var handle = Handlebars._compile.apply(Handlebars, args);
 
     return function() {
-      const result = handle.apply(this, arguments);
+      var result = handle.apply(this, arguments);
   
       if (delimiters[0] !== '{{' && delimiters[1] !== '}}') {
         return unescapeCurly(result);

--- a/test.js
+++ b/test.js
@@ -29,6 +29,16 @@ describe('custom handlebars delimiters', function() {
     testWith(fixture, '{%= name %}Jon SchlinkertJon Schlinkert<%= name %><% name %><<= name >><< name >>%{name}%{ name }');
   });
 
+  it('should use {{...}}', function () {
+    delimiters(hbs, ['{{', '}}']);
+    testWith(fixture, '{%= name %}Jon SchlinkertJon Schlinkert<%= name %><% name %><<= name >><< name >>%{name}%{ name }');
+  });
+
+  it('should not replace __OPEN_CURLY__ when using {{...}}', function () {
+    delimiters(hbs, ['{{', '}}']);
+    testWith('__OPEN_CURLY__ {{name}}', '__OPEN_CURLY__ Jon Schlinkert');
+  });
+
   it('should use <%=...%>', function() {
     delimiters(hbs, ['<%=', '%>']);
     testWith(fixture, '{%= name %}{{ name }}{{{ name }}}Jon Schlinkert<% name %><<= name >><< name >>%{name}%{ name }');
@@ -67,5 +77,10 @@ describe('custom handlebars delimiters', function() {
   it('should handle spaces in first occurence', function() {
     delimiters(hbs, ['%{', '}']);
     testWith("%{ name }", 'Jon Schlinkert');
+  });
+
+  it('should handle wrapping curly braces', function() {
+    delimiters(hbs, ['<%=', '%>']);
+    testWith("{<%=name%>}", '{Jon Schlinkert}');
   });
 });


### PR DESCRIPTION
Change logic to not replace curly braces unless using the default escape strings used by handlebars. Add tests to check for these cases.

Ref #7