### PR TITLE
RegExp and HTML Safe Delimiter Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,11 +31,13 @@ var cache = {};
  */
 
 module.exports = function(Handlebars, delimiters) {
-  if (delimiters[0].slice(-1) !== '=') {
-    delimiters[0] += '(?!=)';
+  var open = escapeRegExp(delimiters[0]);
+  var close = escapeRegExp(delimiters[1]);
+  if (open.slice(-1) !== '=') {
+    open += '(?!=)';
   }
 
-  var source = delimiters[0] + '([\\s\\S]+?)' + delimiters[1];
+  var source = open + '([\\s\\S]+?)' + close;
 
   // Idea for compile method from http://stackoverflow.com/a/19181804/1267639
   if (!Handlebars._compile) {
@@ -45,7 +47,7 @@ module.exports = function(Handlebars, delimiters) {
   Handlebars.compile = function(str) {
     var args = [].slice.call(arguments);
     if (typeof str === 'string') {
-      if(delimiters[0] !== '{{' && delimiters[1] !== '}}') {
+      if (open !== '{{' && close !== '}}') {
         args[0] = escapeDelimiters(args[0]);
       }
       args[0] = replaceDelimiters(args[0], source);
@@ -95,6 +97,13 @@ function replaceDelimiters(str, source, escape) {
 
 function escapeDelimiters(str) {
   return replaceDelimiters(str, '{{([\\s\\S]+?)}}', true);
+}
+
+var matchRegExpSymbols = /[.*+?^${}()|[\]\\]/g;
+
+// https://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
+function escapeRegExp(string) {
+  return string.replace(matchRegExpSymbols, '\\$&');
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports = function(Handlebars, delimiters) {
     return function(tplArgs) {
       tplArgs = [].slice.call(arguments);
       var result = '';
-      compileMap.forEach(part => {
+      compileMap.forEach(function(part) {
         if (typeof part === 'string') {
           // No custom delimiter matched; Escape default open delimiters
           part = part.replace(matchDefaultOpen, '\\$&');
@@ -132,7 +132,7 @@ function wrapWithDelimiters(content, delimiters) {
 
 function mapDelimiters(compileMap, source, delimiters) {
   var result = [];
-  compileMap.forEach(part => {
+  compileMap.forEach(function(part) {
     if (typeof part !== 'string') {
       result.push(part);
       return;

--- a/index.js
+++ b/index.js
@@ -25,15 +25,15 @@ var cache = {};
  * // you can now use handlebars as usual, but with the new delimiters
  * ```
  * @param {Object} `Handlebars`
- * @param {Array} `delimiters` Array with open and close delimiters, like `['<%', '%>']`
+ * @param {Array.<String|RegExp>} `delimiters` Array with open and close delimiters, like `['<%', '%>']`
  * @return {undefined}
  * @api public
  */
 
 module.exports = function(Handlebars, delimiters) {
-  var open = escapeRegExp(delimiters[0]);
-  var close = escapeRegExp(delimiters[1]);
-  if (open.slice(-1) !== '=') {
+  var open = delimiterRegExp(delimiters[0]);
+  var close = delimiterRegExp(delimiters[1]);
+  if (!(delimiters[0] instanceof RegExp) && open.slice(-1) !== '=') {
     open += '(?!=)';
   }
 
@@ -97,6 +97,19 @@ function replaceDelimiters(str, source, escape) {
 
 function escapeDelimiters(str) {
   return replaceDelimiters(str, '{{([\\s\\S]+?)}}', true);
+}
+
+var matchRegExp = /^\/\^?(.*)\$?\/[a-z]*$/i;
+
+/**
+ * Transforms RegExp or string to string escaped to be used in RegExp.
+ * @param {String|RegExp} `delimiter`  RegExp or string to escape
+ * @return {String}
+ * @api private
+ */
+function delimiterRegExp(delimiter) {
+  return !(delimiter instanceof RegExp) ? escapeRegExp(delimiter)
+    : delimiter.toString().replace(matchRegExp, '$1');
 }
 
 var matchRegExpSymbols = /[.*+?^${}()|[\]\\]/g;

--- a/test.js
+++ b/test.js
@@ -86,4 +86,20 @@ describe('custom handlebars delimiters', function() {
     var test = function() { testWith('[= name ]', ''); };
     assert.throws(test, Error, 'Error Thrown for equal sign in expression');
   });
+
+  it('should sanitize non-html delimiters', function() {
+    delimiters(hbs, ['<%', '%>', '<<%', '%>>']);
+    var fixture = '<% html %>';
+    var expectation = '&amp;lt;&amp;gt;';
+    var actual = hbs.compile(fixture)({html: '&lt;&gt;'});
+    assert.equal(actual, expectation);
+  });
+
+  it('should mark safe html delimiters', function() {
+    delimiters(hbs, ['<%', '%>', '<<%', '%>>']);
+    var fixture = '<<% html %>>';
+    var expectation = '&lt;&gt;';
+    var actual = hbs.compile(fixture)({html: '&lt;&gt;'});
+    assert.equal(actual, expectation);
+  });
 });

--- a/test.js
+++ b/test.js
@@ -73,4 +73,17 @@ describe('custom handlebars delimiters', function() {
     delimiters(hbs, ['%{', '}']);
     testWith("%{ name }", 'Jon Schlinkert');
   });
+
+  it('should handle RegExp delimiters', function() {
+    delimiters(hbs, [/[A-M]/, /[N-Z]/]);
+    var fixture = 'A name_B_name_C_name X_name_Y_name_Z_D name W';
+    var expectation = '_name_Y_name_Z_Jon Schlinkert';
+    testWith(fixture, expectation);
+  });
+
+  it('should not modify equal sign query from RegExp open delimiter', function() {
+    delimiters(hbs, [/\[/, /]/]);
+    var test = function() { testWith('[= name ]', ''); };
+    assert.throws(test, Error, 'Error Thrown for equal sign in expression');
+  });
 });

--- a/test.js
+++ b/test.js
@@ -12,7 +12,7 @@ var handlebars = require('handlebars');
 var delimiters = require('./');
 var hbs;
 
-var fixture = '{%= name %}{{ name }}{{{ name }}}<%= name %><% name %><<= name >><< name >>%{name}%{ name }';
+var fixture = '{%= name %}{{ name }}{{{ name }}}<%= name %><% name %><<= name >><< name >>%{name}%{ name }[[ name ]]';
 
 describe('custom handlebars delimiters', function() {
   beforeEach(function() {
@@ -26,37 +26,42 @@ describe('custom handlebars delimiters', function() {
 
   it('should use default delimiters', function() {
     var actual = hbs.compile(fixture)({name: 'Jon Schlinkert'});
-    testWith(fixture, '{%= name %}Jon SchlinkertJon Schlinkert<%= name %><% name %><<= name >><< name >>%{name}%{ name }');
+    testWith(fixture, '{%= name %}Jon SchlinkertJon Schlinkert<%= name %><% name %><<= name >><< name >>%{name}%{ name }[[ name ]]');
   });
 
   it('should use <%=...%>', function() {
     delimiters(hbs, ['<%=', '%>']);
-    testWith(fixture, '{%= name %}{{ name }}{{{ name }}}Jon Schlinkert<% name %><<= name >><< name >>%{name}%{ name }');
+    testWith(fixture, '{%= name %}{{ name }}{{{ name }}}Jon Schlinkert<% name %><<= name >><< name >>%{name}%{ name }[[ name ]]');
   });
 
   it('should use {%=...%}', function() {
     delimiters(hbs, ['{%=', '%}']);
-    testWith(fixture, 'Jon Schlinkert{{ name }}{{{ name }}}<%= name %><% name %><<= name >><< name >>%{name}%{ name }');
+    testWith(fixture, 'Jon Schlinkert{{ name }}{{{ name }}}<%= name %><% name %><<= name >><< name >>%{name}%{ name }[[ name ]]');
   });
 
   it('should use <%...%>', function() {
     delimiters(hbs, ['<%', '%>']);
-    testWith(fixture, '{%= name %}{{ name }}{{{ name }}}<%= name %>Jon Schlinkert<<= name >><< name >>%{name}%{ name }');
+    testWith(fixture, '{%= name %}{{ name }}{{{ name }}}<%= name %>Jon Schlinkert<<= name >><< name >>%{name}%{ name }[[ name ]]');
   });
 
   it('should use <<...>>', function() {
     delimiters(hbs, ['<<', '>>']);
-    testWith(fixture, '{%= name %}{{ name }}{{{ name }}}<%= name %><% name %><<= name >>Jon Schlinkert%{name}%{ name }');
+    testWith(fixture, '{%= name %}{{ name }}{{{ name }}}<%= name %><% name %><<= name >>Jon Schlinkert%{name}%{ name }[[ name ]]');
   });
 
   it('should use <<=...>>', function() {
     delimiters(hbs, ['<<=', '>>']);
-    testWith(fixture, '{%= name %}{{ name }}{{{ name }}}<%= name %><% name %>Jon Schlinkert<< name >>%{name}%{ name }');
+    testWith(fixture, '{%= name %}{{ name }}{{{ name }}}<%= name %><% name %>Jon Schlinkert<< name >>%{name}%{ name }[[ name ]]');
   });
 
   it('should use %{...} with or without spaces', function() {
     delimiters(hbs, ['%{', '}']);
-    testWith(fixture, '{%= name %}{{ name }}{{{ name }}}<%= name %><% name %><<= name >><< name >>Jon SchlinkertJon Schlinkert');
+    testWith(fixture, '{%= name %}{{ name }}{{{ name }}}<%= name %><% name %><<= name >><< name >>Jon SchlinkertJon Schlinkert[[ name ]]');
+  });
+
+  it('should use [[...]]', function() {
+    delimiters(hbs, ['[[', ']]']);
+    testWith(fixture, '{%= name %}{{ name }}{{{ name }}}<%= name %><% name %><<= name >><< name >>%{name}%{ name }Jon Schlinkert');
   });
 
   it('should handle no spaces in first occurence', function() {


### PR DESCRIPTION
The first of these changes escapes regular expression special characters in given delimiter strings, so that they may be more intuitively taken literally (fixes #9).

The second change reintroduces the capability of using explicit RegExp delimiters for those users that still require that feature.